### PR TITLE
feat: add eta and distance to the ride results

### DIFF
--- a/app/dev-dist/sw.js
+++ b/app/dev-dist/sw.js
@@ -85,7 +85,7 @@ define(['./workbox-6a4869df'], (function (workbox) { 'use strict';
     "revision": "3ca0b8505b4bec776b69afdba2768812"
   }, {
     "url": "index.html",
-    "revision": "0.dp6pm5nkv78"
+    "revision": "0.256pe6dl558"
   }], {});
   workbox.cleanupOutdatedCaches();
   workbox.registerRoute(new workbox.NavigationRoute(workbox.createHandlerBoundToURL("index.html"), {

--- a/app/src/components/RideBar.tsx
+++ b/app/src/components/RideBar.tsx
@@ -350,6 +350,7 @@ const RideBar: React.FC<RideBarProps> = ({ fromHome = false, role }) => {
         message: ride.message,
         role: ride.role,
         timestamp: ride.timestamp,
+        // TODO: use enum here for the status i.e. RIDE_STATUS.CONFIRMED
         status: 'CONFIRMED',
         riderId: ride.riderId,
       });

--- a/app/src/interfaces/types.ts
+++ b/app/src/interfaces/types.ts
@@ -13,6 +13,8 @@ export interface RideFormData {
   timestamp?: string;
   status?: string;
   riderId?: string;
+  estimatedTimeOfArrival?: number;
+  distance?: number;
 }
 
 export interface AvailableListProps {

--- a/app/src/pages/RideDetails.tsx
+++ b/app/src/pages/RideDetails.tsx
@@ -195,6 +195,28 @@ const RideDetails: React.FC = () => {
               </p>
             </div>
           </div>
+          {rideDetails.estimatedTimeOfArrival && (
+            <div className="rounded-xl bg-teal-100 p-3 dark:bg-teal-900">
+              <div className="flex items-center gap-2">
+                {role === USER_ROLE.RIDER ? (
+                  <MdOutlineDirectionsBike className="text-lg text-teal-500" />
+                ) : (
+                  <FaWalking className="text-lg text-teal-500" />
+                )}
+                <span className="text-base text-dark dark:text-light">
+                  {role === USER_ROLE.RIDER
+                    ? `Time to reach passenger's location (by bike)`
+                    : `Rider's estimated arrival time (by bike)`}
+                  : ~{rideDetails.estimatedTimeOfArrival} minutes
+                </span>
+                {rideDetails.distance && (
+                  <span className="ml-2 text-sm text-teal-600 dark:text-teal-400">
+                    ({rideDetails.distance.toFixed(1)} km from rider's location)
+                  </span>
+                )}
+              </div>
+            </div>
+          )}
           <div className="space-y-4">
             <div className="flex items-center justify-between">
               <button

--- a/app/src/pages/RideResultsList.tsx
+++ b/app/src/pages/RideResultsList.tsx
@@ -104,6 +104,40 @@ const RideResultsList: React.FC<RideResultsListProps> = ({
                 </p>
               </div>
             </div>
+
+            {ride.distance !== undefined && (
+              <div className="flex items-center justify-between gap-2 border-t border-teal-200/50 pt-2.5 dark:border-teal-700/30">
+                {ride.distance === 0 ? (
+                  <>
+                    <span className="text-xs text-dark dark:text-light">
+                      {role === USER_ROLE.RIDER
+                        ? "You're at the passenger's location"
+                        : 'Rider is at your location'}
+                    </span>
+                    <span className="text-xs font-semibold text-teal-600 dark:text-teal-400">
+                      ({ride.distance.toFixed(1)} km)
+                    </span>
+                  </>
+                ) : (
+                  <>
+                    <span className="text-xs text-dark dark:text-light">
+                      {role === USER_ROLE.RIDER
+                        ? `Time to reach the location`
+                        : `Rider will reach your location in`}{' '}
+                      ~
+                      <strong className="font-semibold">
+                        {ride.estimatedTimeOfArrival}{' '}
+                        {ride.estimatedTimeOfArrival === 1 ? 'min' : 'mins'}
+                      </strong>
+                    </span>
+                    <span className="text-xs font-semibold text-teal-600 dark:text-teal-400">
+                      ({ride.distance.toFixed(1)} km)
+                    </span>
+                  </>
+                )}
+              </div>
+            )}
+
             <div className="flex items-center justify-between gap-3">
               <button
                 type="button"

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -48,6 +48,7 @@ model Ride {
   role        String
   timestamp   DateTime      @default(now())
   rider       User          @relation("RiderRides", fields: [riderId], references: [id])
+  estimatedTimeOfArrival Int?   // ETA in minutes
   riderId     Int
   requests    RideRequest[]
   passengers  User[]        @relation("RidePassengers")

--- a/server/src/ride.controller.ts
+++ b/server/src/ride.controller.ts
@@ -19,6 +19,7 @@ import { getNow } from './utils/date.util';
 import { USER_ROLE, RIDE_STATUS } from './constants/enums';
 import { RideGateway } from './rides/rides.gateway';
 import {
+  calculateETA,
   haversineDistance,
   MAX_RIDE_PROXIMITY_KM,
   estimateCO2FromDistance,
@@ -131,13 +132,25 @@ export class RideController {
       if (!Number.isFinite(ride.fromLat) || !Number.isFinite(ride.fromLng)) {
         return false;
       }
+      // Calculate distance between the current user's "From" location and the matched ride's "From" location
       const dist = haversineDistance(
         fromLatNum,
         fromLngNum,
         ride.fromLat as number,
         ride.fromLng as number,
       );
-      return dist <= MAX_RIDE_PROXIMITY_KM;
+
+      if (dist <= MAX_RIDE_PROXIMITY_KM) {
+        // Calculate ETA based on the mode of transport of the current user
+        const estimatedTimeOfArrival = calculateETA(dist);
+
+        ride.estimatedTimeOfArrival = estimatedTimeOfArrival;
+        ride.distance = dist;
+
+        return true;
+      }
+
+      return false;
     });
 
     return { rides: matchedRides };

--- a/server/src/utils/rideStats.util.ts
+++ b/server/src/utils/rideStats.util.ts
@@ -19,10 +19,23 @@ export const DEG_TO_RAD = Math.PI / 180;
 /**
  * Maximum allowed proximity for ride matching (in km)
  */
-export const MAX_RIDE_PROXIMITY_KM = 2;
+export const MAX_RIDE_PROXIMITY_KM = 3;
 
 /**
  * DEFRA 2024 average car emission factor (kg CO2 per km)
+ */
+
+/**
+ * Speed constants for transport (km/h)
+ *
+ * https://smarter-usa.org/wp-content/uploads/2019/01/1-Motorcycle-Speeds-at-Urban-Intersections.pdf
+ */
+export enum TransportSpeed {
+  BIKE = 38.28,
+}
+
+/**
+ * Emission factors for different modes of transport (kg CO2 per km)
  */
 export enum EmissionFactor {
   BIKE = 0.016,
@@ -75,4 +88,25 @@ export function estimateCO2FromDistance(
   vehicle: EmissionFactor = EmissionFactor.BIKE, // Default to bike
 ): number {
   return distanceKm * vehicle;
+}
+
+/**
+ * Calculates the estimated time of arrival (ETA) based on distance and transport mode.
+ *
+ * @param distanceKm - Distance to travel in kilometers
+ * @param role - User role (rider or passenger) to determine transport mode
+ * @returns Estimated time of arrival in minutes, rounded to nearest minute
+ *
+ * @example
+ * const eta = calculateETA(5, USER_ROLE.RIDER); // Returns ETA for a 5km bike ride
+ */
+export function calculateETA(distanceKm: number): number {
+  // Always use bike speed since rider will be on bike
+  const speed = TransportSpeed.BIKE;
+
+  // Convert distance and speed to consistent units (km and hours)
+  const timeInHours = distanceKm / speed;
+
+  // Convert to minutes and round to nearest minute
+  return Math.round(timeInHours * 60);
 }


### PR DESCRIPTION
This pull request introduces enhancements to the ride matching and display features, focusing on providing users with estimated time of arrival (ETA) and distance information. These improvements affect both the backend ride matching logic and the frontend user experience, making ride details more informative and actionable.

### Screenshots

<img width="590" height="390" alt="image" src="https://github.com/user-attachments/assets/444ed08f-b73f-411d-9ec5-876f6f326417" />

<img width="588" height="397" alt="image" src="https://github.com/user-attachments/assets/3b9b62c0-4f1a-48d9-91e9-6a12d8f3b1d3" />
