### PR TITLE
bug-fix: duplicate ride entries in database

### DIFF
--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -62,6 +62,7 @@ model Ride {
   distance     Float?        // Distance in kilometers, calculated when ride is confirmed
   co2Saved     Float?        // CO2 saved in kg
   peopleImpacted Int?        // Number of people impacted (passengers)
+  matchGroupId String?       // UUID to group matched rides together
 }
 
 enum RideStatus {

--- a/server/src/ride.controller.ts
+++ b/server/src/ride.controller.ts
@@ -12,6 +12,7 @@ import {
   NotFoundException,
   BadRequestException,
 } from '@nestjs/common';
+import { randomUUID } from 'crypto';
 import { PrismaService } from './prisma.service';
 import { RideGateway } from './rides/rides.gateway';
 import { WINSTON_MODULE_NEST_PROVIDER, WinstonLogger } from 'nest-winston';
@@ -394,14 +395,35 @@ export class RideController {
       orderBy: { timestamp: 'desc' },
     });
 
+    // Group rides by matchGroupId to prevent duplicates
+    // TODO (Performance): Optimize by handling deduplication at database level using
+    // GROUP BY or DISTINCT ON to reduce memory usage and improve performance for large datasets
+    // instead of filtering in memory. This becomes critical with 1000+ rides.
+    const uniqueRides: typeof rides = [];
+    const seenMatchGroups = new Set();
+
+    for (const ride of rides) {
+      if (ride.matchGroupId) {
+        // If this ride has a matchGroupId and we haven't seen it yet
+        if (!seenMatchGroups.has(ride.matchGroupId)) {
+          seenMatchGroups.add(ride.matchGroupId);
+          uniqueRides.push(ride);
+        }
+      } else {
+        // If no matchGroupId, include the ride (not a matched ride)
+        uniqueRides.push(ride);
+      }
+    }
+
     this.logger.log({
       level: 'info',
       message: `Fetched ride history`,
       tag: 'ride',
       userId,
-      rideCount: rides.length,
+      rideCount: uniqueRides.length,
+      originalRideCount: rides.length,
     });
-    return { rides };
+    return { rides: uniqueRides };
   }
 
   @Get(':id')
@@ -564,6 +586,9 @@ export class RideController {
       throw new NotFoundException('Target ride not found');
     }
 
+    // Generate a unique match group ID for these paired rides
+    const matchGroupId = randomUUID();
+
     // Update both rides with confirmed status and proper rider/passenger assignments
     await this.prisma.ride.updateMany({
       where: { id: { in: [rideId, targetRideId] } },
@@ -571,6 +596,7 @@ export class RideController {
         status: RIDE_STATUS.CONFIRMED,
         riderId: updatedRiderId,
         passengerId: updatedPassengerId,
+        matchGroupId: matchGroupId,
       },
     });
 


### PR DESCRIPTION
## bug-fix: duplicate ride entries in database

This pull request introduces a mechanism to group matched rides together using a unique identifier and ensures that ride history queries do not return duplicate entries for matched rides. The main changes involve updating the data model, modifying ride confirmation logic, and filtering ride history responses.

**Ride grouping and history deduplication:**

* [`server/prisma/schema.prisma`](diffhunk://#diff-f15e3ac1b46f7ac4b6b782547e2ca4d45a886d518c81302a82eab7164c514cf2R65): Added a new optional `matchGroupId` field (UUID) to the `Ride` model to group matched rides together.
* [`server/src/ride.controller.ts`](diffhunk://#diff-06c88510a01940bc8901e4638729fd4de897768e4e163ff3f0b825b6b0537b62R15): When confirming a ride match, generates a unique `matchGroupId` (using `randomUUID`) and assigns it to both rides in the match. [[1]](diffhunk://#diff-06c88510a01940bc8901e4638729fd4de897768e4e163ff3f0b825b6b0537b62R15) [[2]](diffhunk://#diff-06c88510a01940bc8901e4638729fd4de897768e4e163ff3f0b825b6b0537b62R586-R596)
* [`server/src/ride.controller.ts`](diffhunk://#diff-06c88510a01940bc8901e4638729fd4de897768e4e163ff3f0b825b6b0537b62R398-R423): Updates the ride history endpoint to filter out duplicate rides by grouping them using `matchGroupId`, ensuring only one ride per group is returned in the response. The response now also includes both the filtered and original ride counts in the log for better traceability.

### Screenshots
<img width="1857" height="212" alt="image" src="https://github.com/user-attachments/assets/a22bba95-33bd-4cf7-96b3-ad362b0a4292" />
