### PR TITLE
feat: add API and fetch people impacted by a user with ride counts

### DIFF
--- a/app/src/components/PeopleImpactedModal.tsx
+++ b/app/src/components/PeopleImpactedModal.tsx
@@ -1,11 +1,6 @@
 import Modal from './ui/Modal';
 import { AVATAR_GRID_CONFIG } from '../constants/enums';
-
-interface Person {
-  id: number;
-  name: string;
-  img: string;
-}
+import { Person } from '../interfaces/types';
 
 interface PeopleImpactedModalProps {
   onClose: () => void;
@@ -17,7 +12,6 @@ const PeopleImpactedModal = ({ onClose, people }: PeopleImpactedModalProps) => {
 
   return (
     <>
-      {/* // TODO: Filter ride based on maximum ride made */}
       <Modal onClose={onClose} className="w-full">
         <div className="mx-auto w-full max-w-md overflow-hidden border border-dark/20 bg-white shadow dark:border-light/20 dark:bg-dark md:rounded-xl">
           <h3
@@ -37,7 +31,7 @@ const PeopleImpactedModal = ({ onClose, people }: PeopleImpactedModalProps) => {
                   <img
                     src={person.img || DEFAULT_AVATAR_URL}
                     alt={person.name}
-                    className="size-12 rounded-full border-2 border-teal-200 object-cover dark:border-teal-600"
+                    className="size-12 rounded-full border-2 border-teal-200 bg-white object-cover dark:border-teal-600 dark:bg-dark"
                   />
                   {index < MAX_VISIBLE_SLOTS && (
                     <span className="absolute -right-0.5 -top-0.5 flex size-4 items-center justify-center rounded-full bg-teal-500 text-xs font-medium text-white">
@@ -48,9 +42,7 @@ const PeopleImpactedModal = ({ onClose, people }: PeopleImpactedModalProps) => {
                 <div className="flex-1">
                   <h3 className="font-medium">{person.name}</h3>
                   <p className="text-xs opacity-80">
-                    Total rides completed:{' '}
-                    {/* // TODO: Add total number of ride made with that person */}
-                    <strong>{Math.floor(Math.random() * 20) + 1}</strong>
+                    Total rides completed: <strong>{person.rideCount}</strong>
                   </p>
                 </div>
               </div>

--- a/app/src/components/ReflectionDashboard.tsx
+++ b/app/src/components/ReflectionDashboard.tsx
@@ -5,7 +5,6 @@ import { useNavigate } from 'react-router-dom';
 
 import { ReflectionStats, RideHistory } from '../interfaces/types';
 import { ROUTE_REDEEM } from '../constants/routes';
-import { getPeopleImpactedFromRides } from '../utils/reflectionUtils';
 
 import UserCard from './UserCard';
 import TitleBar from './ui/TitleBar';
@@ -21,12 +20,9 @@ interface ReflectionDashboardProps {
 
 const ReflectionDashboard = ({
   stats,
-  completedRides,
   currentUserId,
 }: ReflectionDashboardProps) => {
   const navigate = useNavigate();
-
-  const people = getPeopleImpactedFromRides(completedRides, currentUserId);
 
   return (
     <div className="grid grid-cols-1 rounded-3xl border-t-0 shadow-sm md:border md:border-t-0 lg:grid-cols-3">
@@ -138,7 +134,7 @@ const ReflectionDashboard = ({
       <div className="col-span-1 rounded-3xl rounded-b-none bg-none dark:bg-teal-900 md:bg-teal-50">
         <div className="relative flex items-center justify-center space-y-3 rounded-3xl rounded-t-none border border-x-0 border-t-0 border-teal-300/50 bg-white pb-4 pt-1 dark:bg-dark">
           {/* <PeopleAvatarGrid people={people} /> */}
-          <PeopleImpactedWithScore people={people} userId={currentUserId} />
+          <PeopleImpactedWithScore userId={currentUserId} />
           <TitleBar
             // content={
             //   people.length > 0

--- a/app/src/components/ui/PeopleImpactedWithScore.tsx
+++ b/app/src/components/ui/PeopleImpactedWithScore.tsx
@@ -2,32 +2,25 @@ import { useState, useEffect, useMemo } from 'react';
 import { TbPlus } from 'react-icons/tb';
 
 import { AVATAR_GRID_CONFIG } from '../../constants/enums';
-import { AverageScoreResult } from '../../interfaces/types';
+import { AverageScoreResult, Person } from '../../interfaces/types';
 
 import {
   getRemainingEmojis,
   getScoreDescription,
   getAverageScoreEmoji,
 } from '../../utils/utils';
-import { fetchUserAverageScore } from '../../utils/api';
+import { fetchUserAverageScore, fetchPeopleImpacted } from '../../utils/api';
 
 import Tooltip from './Tooltip';
 import PeopleImpactedModal from '../PeopleImpactedModal';
 
-interface Person {
-  id: number;
-  name: string;
-  img: string;
-}
-
 interface PeopleAvatarGridProps {
-  people: Person[];
   userId: number;
-  className?: string;
 }
 
-const PeopleImpactedWithScore = ({ people, userId }: PeopleAvatarGridProps) => {
+const PeopleImpactedWithScore = ({ userId }: PeopleAvatarGridProps) => {
   const [showModal, setShowModal] = useState(false);
+  const [people, setPeople] = useState<Person[]>([]);
   const [averageScoreData, setAverageScoreData] =
     useState<AverageScoreResult | null>(null);
 
@@ -42,19 +35,23 @@ const PeopleImpactedWithScore = ({ people, userId }: PeopleAvatarGridProps) => {
       : [];
   }, [averageScoreData?.averageScore]);
 
-  // Fetch average score on component mount
+  // Fetch average score and people impacted data on component mount
   useEffect(() => {
-    const fetchScore = async () => {
+    const fetchData = async () => {
       try {
-        const scoreData = await fetchUserAverageScore(userId);
+        const [scoreData, peopleData] = await Promise.all([
+          fetchUserAverageScore(userId),
+          fetchPeopleImpacted(userId),
+        ]);
+
         setAverageScoreData(scoreData);
+        setPeople(peopleData.people);
       } catch (error) {
-        console.error('Error fetching average score:', error);
-        // API utility already handles error fallbacks
+        console.error('Error fetching user data:', error);
       }
     };
 
-    fetchScore();
+    fetchData();
   }, [userId]);
 
   const slots = Array.from(
@@ -87,7 +84,7 @@ const PeopleImpactedWithScore = ({ people, userId }: PeopleAvatarGridProps) => {
                   <img
                     src={hasData ? person!.img : DEFAULT_AVATAR_URL}
                     alt={hasData ? person!.name : 'Unlock slot'}
-                    className={`transition-150 inline-block aspect-square size-9 rounded-full object-cover group-hover:scale-110 md:size-11 ${
+                    className={`transition-150 inline-block aspect-square size-9 rounded-full bg-white object-cover group-hover:scale-110 dark:bg-dark md:size-11 ${
                       hasData
                         ? 'border-2 border-teal-300 group-hover:border-teal-400 dark:border-teal-700 dark:group-hover:border-teal-600'
                         : 'transition-150 border-2 border-teal-300 bg-light p-1 grayscale hover:grayscale-0 group-hover:border-teal-400 dark:border-0 dark:border-teal-700 dark:bg-dark dark:group-hover:border-teal-600'

--- a/app/src/constants/api.ts
+++ b/app/src/constants/api.ts
@@ -9,3 +9,5 @@ export const API_RIDES_FEEDBACK = `${API_RIDES}/feedback`;
 export const API_USER_KARMA_POINTS = `${API_RIDES}/user/:userId/karma-points`;
 
 export const API_USER_AVERAGE_SCORE = `${API_RIDES}/user/:userId/average-score`;
+
+export const API_USER_PEOPLE_IMPACTED = `${API_RIDES}/user/:userId/people-impacted`;

--- a/app/src/interfaces/types.ts
+++ b/app/src/interfaces/types.ts
@@ -1,5 +1,12 @@
 import { RIDE_STATUS, USER_ROLE } from '../constants/enums';
 
+export interface Person {
+  id: number;
+  name: string;
+  img: string;
+  rideCount: number;
+}
+
 export interface RideFormData {
   id?: string;
   from: string;

--- a/app/src/utils/api.ts
+++ b/app/src/utils/api.ts
@@ -1,5 +1,10 @@
-import { API_USER_AVERAGE_SCORE } from '../constants/api';
+import {
+  API_USER_AVERAGE_SCORE,
+  API_USER_PEOPLE_IMPACTED,
+} from '../constants/api';
+
 import { AverageScoreResult } from '../interfaces/types';
+
 import { createEmptyEmojiBreakdown } from './utils';
 
 export async function apiFetch<T>(
@@ -22,6 +27,26 @@ export async function apiFetch<T>(
 }
 
 /**
+ * Helper function to build full API URL with parameter substitution
+ * @param apiEndpoint - The API endpoint constant (e.g., API_USER_AVERAGE_SCORE)
+ * @param params - Object containing parameter replacements (e.g., { userId: '123' })
+ * @returns Full API URL ready for fetch
+ */
+function buildApiUrl(
+  apiEndpoint: string,
+  params: Record<string, string>,
+): string {
+  let url = apiEndpoint;
+
+  // Replace all parameters in the endpoint (e.g., :userId -> actual ID)
+  Object.entries(params).forEach(([key, value]) => {
+    url = url.replace(`:${key}`, value);
+  });
+
+  return `${import.meta.env.VITE_API_BASE_URL}${url}`;
+}
+
+/**
  * Fetches the average score for a user from the server
  * @param userId - The user ID to fetch the score for
  * @returns Promise resolving to the average score result
@@ -30,9 +55,9 @@ export const fetchUserAverageScore = async (
   userId: number,
 ): Promise<AverageScoreResult> => {
   try {
-    const url = API_USER_AVERAGE_SCORE.replace(':userId', userId.toString());
-    const fullUrl = `${import.meta.env.VITE_API_BASE_URL}${url}`;
-
+    const fullUrl = buildApiUrl(API_USER_AVERAGE_SCORE, {
+      userId: userId.toString(),
+    });
     const response = await apiFetch<AverageScoreResult>(fullUrl);
     return response;
   } catch (error) {
@@ -42,6 +67,49 @@ export const fetchUserAverageScore = async (
       averageScore: null,
       totalFeedback: 0,
       emojiBreakdown: createEmptyEmojiBreakdown(),
+    };
+  }
+};
+
+/**
+ * Fetches people impacted data for a user (users they've ridden with and ride counts)
+ * @param userId - The user ID to fetch people impacted data for
+ * @returns Promise resolving to array of people with ride counts
+ */
+export const fetchPeopleImpacted = async (
+  userId: number,
+): Promise<{
+  people: Array<{
+    id: number;
+    name: string;
+    img: string;
+    rideCount: number;
+  }>;
+  totalImpacted: number;
+}> => {
+  try {
+    const fullUrl = buildApiUrl(API_USER_PEOPLE_IMPACTED, {
+      userId: userId.toString(),
+    });
+
+    const response = await apiFetch<{
+      people: Array<{
+        id: number;
+        name: string;
+        img: string;
+        rideCount: number;
+      }>;
+      totalImpacted: number;
+    }>(fullUrl);
+
+    return response;
+  } catch (error) {
+    console.error('Error fetching people impacted data:', error);
+
+    // Return empty data as fallback
+    return {
+      people: [],
+      totalImpacted: 0,
     };
   }
 };

--- a/server/src/ride.controller.ts
+++ b/server/src/ride.controller.ts
@@ -13,6 +13,7 @@ import {
   ParseIntPipe,
   NotFoundException,
   BadRequestException,
+  InternalServerErrorException,
 } from '@nestjs/common';
 import { WINSTON_MODULE_NEST_PROVIDER, WinstonLogger } from 'nest-winston';
 
@@ -1380,6 +1381,135 @@ export class RideController {
         userId,
       });
       throw new BadRequestException('Error calculating average score');
+    }
+  }
+
+  @Get('/user/:userId/people-impacted')
+  /**
+   * Get people impacted by a user (users they've ridden with and ride counts)
+   * Returns users ranked by number of rides completed together
+   * Properly handles matchGroupId to avoid double-counting matched rides
+   * @param userId The user ID to get people impacted data for
+   * @returns Object containing people array and total count
+   */
+  async getPeopleImpacted(
+    @Param('userId', ParseIntPipe) userId: number,
+  ): Promise<{
+    people: Array<{
+      id: number;
+      name: string;
+      img: string;
+      rideCount: number;
+    }>;
+    totalImpacted: number;
+  }> {
+    try {
+      // Get all completed rides where user was involved (as rider or passenger)
+      const allRides = await this.prisma.ride.findMany({
+        where: {
+          status: RIDE_STATUS.COMPLETED,
+          OR: [{ riderId: userId }, { passengerId: userId }],
+        },
+        select: {
+          id: true,
+          riderId: true,
+          passengerId: true,
+          matchGroupId: true,
+        },
+      });
+
+      // Deduplicate rides by matchGroupId to avoid counting matched rides twice
+      const uniqueRides = new Map<string, (typeof allRides)[0]>();
+
+      allRides.forEach((ride) => {
+        if (ride.matchGroupId) {
+          // If ride has matchGroupId, use it as key to deduplicate
+          if (!uniqueRides.has(ride.matchGroupId)) {
+            uniqueRides.set(ride.matchGroupId, ride);
+          }
+        } else {
+          // If no matchGroupId, use ride ID as unique key
+          uniqueRides.set(`ride_${ride.id}`, ride);
+        }
+      });
+
+      // Count partners from deduplicated rides
+      const partnerCounts = new Map<number, number>();
+
+      Array.from(uniqueRides.values()).forEach((ride) => {
+        let partnerId: number | null = null;
+
+        if (ride.riderId === userId && ride.passengerId) {
+          // User was rider, partner is passenger
+          partnerId = ride.passengerId;
+        } else if (ride.passengerId === userId && ride.riderId) {
+          // User was passenger, partner is rider
+          partnerId = ride.riderId;
+        }
+
+        if (partnerId) {
+          const current = partnerCounts.get(partnerId) || 0;
+          partnerCounts.set(partnerId, current + 1);
+        }
+      });
+
+      // Get user details for all partners
+      const partnerIds = Array.from(partnerCounts.keys());
+
+      if (partnerIds.length === 0) {
+        return { people: [], totalImpacted: 0 };
+      }
+
+      const partnerUsers = await this.prisma.user.findMany({
+        where: {
+          id: { in: partnerIds },
+        },
+        select: {
+          id: true,
+          fullname: true,
+          profilePicture: true,
+        },
+      });
+
+      // Combine user data with ride counts and sort
+      const people = partnerUsers
+        .map((user) => ({
+          id: user.id,
+          name: user.fullname,
+          img: user.profilePicture || '',
+          rideCount: partnerCounts.get(user.id) || 0,
+        }))
+        .sort((a, b) => b.rideCount - a.rideCount);
+
+      this.logger.log({
+        level: 'info',
+        message: `People impacted data fetched for user ${userId}`,
+        tag: 'ride',
+        userId,
+        totalRidesFound: allRides.length,
+        uniqueRidesAfterDedup: uniqueRides.size,
+        totalImpacted: people.length,
+        topPartners: people.slice(0, 3).map((p) => ({
+          name: p.name,
+          rides: p.rideCount,
+        })),
+      });
+
+      return {
+        people,
+        totalImpacted: people.length,
+      };
+    } catch (error) {
+      this.logger.error({
+        level: 'error',
+        message: `Failed to fetch people impacted for user ${userId}`,
+        tag: 'ride',
+        userId,
+        error: (error as Error).message,
+      });
+      throw new InternalServerErrorException(
+        'Failed to fetch people impacted data',
+      );
     }
   }
 


### PR DESCRIPTION
This pull request adds a new "People Impacted" feature, which enables the frontend to display a list of users a person has ridden with, along with the number of rides completed together. It introduces a new backend API endpoint, updates data fetching logic on the frontend, and refines UI components to show accurate ride counts and improved avatar styling.

**Backend: People Impacted API**

* Added a new GET endpoint `/user/:userId/people-impacted` to `ride.controller.ts` that returns a deduplicated list of users the given user has ridden with, including ride counts, and properly handles matched rides to avoid double-counting.

**Frontend: Data Fetching and Types**

* Created a new API call `fetchPeopleImpacted` in `api.ts` to fetch people impacted data and updated the API constants to include the new endpoint.


## Related Issue
- #79 

## Screenshot

<img width="1920" height="975" alt="image" src="https://github.com/user-attachments/assets/75407e38-b1e1-4523-9ef3-f768f46b5f1f" />
