### PR TITLE
chore: implement unit testing on the server

### DIFF
--- a/UNIT_TESTING.md
+++ b/UNIT_TESTING.md
@@ -1,0 +1,175 @@
+# Unit Testing in Commuto
+
+This document describes the unit testing strategy, setup, and conventions for both the frontend (React) and backend (NestJS) of the Commuto project.
+
+---
+
+## Table of Contents
+
+- [Overview](#overview)
+- [Frontend (React) Testing](#frontend-react-testing)
+  - [Setup](#setup)
+  - [Running Tests](#running-tests)
+  - [Writing Tests](#writing-tests)
+  - [Example Tests](#example-tests)
+- [Backend (NestJS) Testing](#backend-nestjs-testing)
+  - [Setup](#setup-1)
+  - [Running Tests](#running-tests-1)
+  - [Writing Tests](#writing-tests-1)
+  - [Example Tests](#example-tests-1)
+- [Best Practices](#best-practices)
+
+---
+
+## Overview
+
+- **Frontend**: Uses [Jest](https://jestjs.io/) and [React Testing Library](https://testing-library.com/docs/react-testing-library/intro/) for unit and component tests.
+- **Backend**: Uses [Jest](https://jestjs.io/) (already integrated with NestJS) for unit and integration tests.
+
+---
+
+## Frontend (React) Testing
+
+### Setup
+
+Dependencies (already installed):
+
+- `jest`
+- `@testing-library/react`
+- `@testing-library/jest-dom`
+- `@testing-library/user-event`
+- `ts-jest`
+- `@types/jest`
+
+Add the following to your `package.json` (if not present):
+
+```json
+"scripts": {
+  "test": "jest"
+}
+```
+
+Add a `jest.config.js` in the `app/` directory:
+
+```js
+module.exports = {
+  preset: "ts-jest",
+  testEnvironment: "jsdom",
+  moduleFileExtensions: ["ts", "tsx", "js", "jsx"],
+  setupFilesAfterEnv: ["@testing-library/jest-dom/extend-expect"],
+  testMatch: ["**/__tests__/**/*.[jt]s?(x)", "**/?(*.)+(test).[jt]s?(x)"],
+};
+```
+
+### Running Tests
+
+From the `app/` directory:
+
+```bash
+pnpm test
+```
+
+### Writing Tests
+
+- Place tests in `src/__tests__/` or alongside components as `.test.tsx`/`.test.ts` files.
+- Use [React Testing Library](https://testing-library.com/docs/react-testing-library/intro/) for component tests.
+- Use Jest for utility and logic tests.
+
+### Example Tests
+
+- `src/__tests__/App.test.tsx`: Renders the main app and checks for Navbar/Footer.
+- `src/__tests__/functions.test.ts`: Tests utility functions.
+
+---
+
+## Backend (NestJS) Testing
+
+### Setup
+
+- Jest is already configured in `server/package.json` with a `jest` section.
+- All backend unit tests are organized in the `server/__tests__/` directory, outside of the main `src/` codebase for clarity and maintainability.
+- The Jest configuration uses `testMatch` to look for tests in `__tests__` only. No `.spec.ts` files should exist in `src/`.
+
+**Example Jest config in `server/package.json`:**
+
+```json
+"jest": {
+  "preset": "ts-jest",
+  "testEnvironment": "node",
+  "moduleFileExtensions": ["ts", "js", "json"],
+  "testMatch": ["<rootDir>/__tests__/**/*.spec.ts"]
+}
+```
+
+### Directory Structure
+
+```
+server/
+  __tests__/
+    controllers/
+      karma.controller.spec.ts
+      ...
+    root/
+      app.module.spec.ts
+      app.service.spec.ts
+      env.service.spec.ts
+      logger.config.spec.ts
+      prisma.service.spec.ts
+      ...
+    utils/
+      timeWindow.util.spec.ts
+      ...
+```
+
+### Running Tests
+
+From the `server/` directory:
+
+```bash
+pnpm test
+```
+
+### Writing Tests
+
+- Place all backend unit tests in the `server/__tests__/` directory, mirroring the structure of your codebase (e.g., `controllers/`, `root/`, `utils/`).
+- Use `.spec.ts` files for all test files.
+- Use NestJS testing utilities (`@nestjs/testing`) for controllers and services.
+- Use proper type-safe mocks for dependencies (e.g., `as unknown as ConfigService`).
+- Keep tests isolated, deterministic, and independent of external systems (mock Prisma, DB, etc.).
+- Use fixed dates/times in tests for deterministic results.
+
+### Example Tests
+
+- `__tests__/controllers/karma.controller.spec.ts`: Tests controller-service interaction for karma redemption.
+- `__tests__/root/app.service.spec.ts`: Tests `AppService` logic.
+- `__tests__/root/prisma.service.spec.ts`: Tests PrismaService instantiation and connection.
+- `__tests__/root/logger.config.spec.ts`: Tests logger config export.
+- `__tests__/root/app.module.spec.ts`: Smoke test for module definition.
+- `__tests__/utils/timeWindow.util.spec.ts`: Tests time window calculation with a fixed UTC date.
+
+### Additional Recommendations
+
+- All test files should be outside `src/` to keep the codebase clean and maintainable.
+- Use descriptive test names and group related tests with `describe`.
+- Use mocks for all external dependencies (database, APIs, etc.).
+- Run tests in CI/CD for every PR to ensure code quality.
+
+For more advanced mocking and test patterns, see the official [NestJS Testing](https://docs.nestjs.com/fundamentals/testing) documentation.
+
+---
+
+## Best Practices
+
+- Write tests for all business logic, utility functions, and React components.
+- Use mocks for external dependencies (API, DB, etc.).
+- Keep tests isolated and deterministic.
+- Use descriptive test names and group related tests with `describe`.
+- Run tests in CI/CD for every PR.
+
+---
+
+For more details, see the official docs:
+
+- [Jest](https://jestjs.io/docs/getting-started)
+- [React Testing Library](https://testing-library.com/docs/intro/)
+- [NestJS Testing](https://docs.nestjs.com/fundamentals/testing)

--- a/server/__tests__/controllers/app.controller.spec.ts
+++ b/server/__tests__/controllers/app.controller.spec.ts
@@ -1,6 +1,8 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { AppController } from './app.controller';
-import { AppService } from './app.service';
+import { WINSTON_MODULE_NEST_PROVIDER } from 'nest-winston';
+
+import { AppService } from '../../src/app.service';
+import { AppController } from '../../src/app.controller';
 
 describe('AppController', () => {
   let appController: AppController;
@@ -8,7 +10,19 @@ describe('AppController', () => {
   beforeEach(async () => {
     const app: TestingModule = await Test.createTestingModule({
       controllers: [AppController],
-      providers: [AppService],
+      providers: [
+        AppService,
+        {
+          provide: WINSTON_MODULE_NEST_PROVIDER,
+          useValue: {
+            log: jest.fn(),
+            error: jest.fn(),
+            warn: jest.fn(),
+            debug: jest.fn(),
+            verbose: jest.fn(),
+          },
+        },
+      ],
     }).compile();
 
     appController = app.get<AppController>(AppController);

--- a/server/__tests__/controllers/karma.controller.spec.ts
+++ b/server/__tests__/controllers/karma.controller.spec.ts
@@ -1,0 +1,68 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { WINSTON_MODULE_NEST_PROVIDER } from 'nest-winston';
+
+import { KarmaController } from '../../src/karma.controller';
+import { REDEMPTION_STATUS } from '../../src/constants/enums';
+import { KarmaRedemptionService } from '../../src/services/karma-redemption.service';
+
+describe('KarmaController', () => {
+  let controller: KarmaController;
+  let service: KarmaRedemptionService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [KarmaController],
+      providers: [
+        {
+          provide: KarmaRedemptionService,
+          useValue: {
+            redeemReward: jest.fn(),
+            getUserRedemptions: jest.fn(),
+            updateRedemptionStatus: jest.fn(),
+          },
+        },
+        {
+          provide: WINSTON_MODULE_NEST_PROVIDER,
+          useValue: { log: jest.fn() },
+        },
+      ],
+    }).compile();
+    controller = module.get<KarmaController>(KarmaController);
+    service = module.get<KarmaRedemptionService>(KarmaRedemptionService);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+
+  it('should call redeemReward on service', async () => {
+    const dto = {
+      userId: 1,
+      rewardId: 'r1',
+      rewardName: 'Test',
+      karmaPointsCost: 10,
+      description: 'desc',
+    };
+    const mockResult = {
+      message: 'Reward redeemed successfully',
+      redemption: {
+        id: 1,
+        rewardId: 'r1',
+        rewardName: 'Test',
+        karmaPointsCost: 10,
+        redemptionCode: 'TEST-123',
+        status: REDEMPTION_STATUS.ACTIVE,
+        expiresAt: new Date(),
+        redeemedAt: new Date(),
+      },
+      remainingKarmaPoints: 90,
+      success: true,
+    };
+    const redeemSpy = jest
+      .spyOn(service, 'redeemReward')
+      .mockResolvedValue(mockResult);
+    const result = await controller.redeemReward(dto);
+    expect(redeemSpy).toHaveBeenCalledWith(dto);
+    expect(result).toBe(mockResult);
+  });
+});

--- a/server/__tests__/root/app.module.spec.ts
+++ b/server/__tests__/root/app.module.spec.ts
@@ -1,0 +1,7 @@
+import { AppModule } from '../../src/app.module';
+
+describe('AppModule', () => {
+  it('should be defined', () => {
+    expect(AppModule).toBeDefined();
+  });
+});

--- a/server/__tests__/root/app.service.spec.ts
+++ b/server/__tests__/root/app.service.spec.ts
@@ -1,0 +1,16 @@
+import { LoggerService } from '@nestjs/common';
+import { AppService } from '../../src/app.service';
+
+describe('AppService', () => {
+  it('should return welcome message', () => {
+    const mockLogger: LoggerService = {
+      log: jest.fn(),
+      error: jest.fn(),
+      warn: jest.fn(),
+      debug: jest.fn(),
+      verbose: jest.fn(),
+    };
+    const service = new AppService(mockLogger);
+    expect(service.getHello()).toBe('Welcome to Commuto!');
+  });
+});

--- a/server/__tests__/root/env.service.spec.ts
+++ b/server/__tests__/root/env.service.spec.ts
@@ -1,0 +1,20 @@
+import { ConfigService } from '@nestjs/config';
+import { EnvService } from '../../src/env.service';
+
+describe('EnvService', () => {
+  it('should return true if NODE_ENV is development', () => {
+    const configService = {
+      get: jest.fn().mockReturnValue('development'),
+    } as unknown as ConfigService;
+    const envService = new EnvService(configService);
+    expect(envService.isDev).toBe(true);
+  });
+
+  it('should return false if NODE_ENV is not development', () => {
+    const configService = {
+      get: jest.fn().mockReturnValue('production'),
+    } as unknown as ConfigService;
+    const envService = new EnvService(configService);
+    expect(envService.isDev).toBe(false);
+  });
+});

--- a/server/__tests__/root/logger.config.spec.ts
+++ b/server/__tests__/root/logger.config.spec.ts
@@ -1,0 +1,8 @@
+import { winstonLoggerConfig } from '../../src/logger.config';
+
+describe('winstonLoggerConfig', () => {
+  it('should export a config object with transports', () => {
+    expect(winstonLoggerConfig).toHaveProperty('transports');
+    expect(Array.isArray(winstonLoggerConfig.transports)).toBe(true);
+  });
+});

--- a/server/__tests__/root/prisma.service.spec.ts
+++ b/server/__tests__/root/prisma.service.spec.ts
@@ -1,0 +1,16 @@
+import { LoggerService } from '@nestjs/common';
+import { PrismaService } from '../../src/prisma.service';
+
+describe('PrismaService', () => {
+  it('should instantiate and connect without error', async () => {
+    const mockLogger: LoggerService = {
+      log: jest.fn(),
+      error: jest.fn(),
+      warn: jest.fn(),
+      debug: jest.fn(),
+      verbose: jest.fn(),
+    };
+    const service = new PrismaService(mockLogger);
+    await expect(service.onModuleInit()).resolves.not.toThrow();
+  });
+});

--- a/server/__tests__/services/karma-calculation.service.spec.ts
+++ b/server/__tests__/services/karma-calculation.service.spec.ts
@@ -1,0 +1,26 @@
+import { FEEDBACK_EMOJI } from '../../src/constants/enums';
+import { KarmaCalculationService } from '../../src/services/karma-calculation.service';
+
+describe('KarmaCalculationService', () => {
+  it('calculates karma points for short distance and satisfied feedback', () => {
+    const result = KarmaCalculationService.calculateKarmaPoints({
+      distance: 2,
+      feedbackRating: FEEDBACK_EMOJI.SATISFIED,
+    });
+    expect(result.totalPoints).toBeGreaterThan(0);
+    expect(result.distanceTier).toBeDefined();
+    expect(result.sentimentBonus).toBeGreaterThanOrEqual(0);
+  });
+
+  it('applies sentiment bonus correctly', () => {
+    const satisfied = KarmaCalculationService.calculateKarmaPoints({
+      distance: 5,
+      feedbackRating: FEEDBACK_EMOJI.SATISFIED,
+    });
+    const neutral = KarmaCalculationService.calculateKarmaPoints({
+      distance: 5,
+      feedbackRating: FEEDBACK_EMOJI.NEUTRAL,
+    });
+    expect(satisfied.totalPoints).toBeGreaterThan(neutral.totalPoints);
+  });
+});

--- a/server/__tests__/services/karma-redemption.service.spec.ts
+++ b/server/__tests__/services/karma-redemption.service.spec.ts
@@ -1,0 +1,47 @@
+import { Test, TestingModule } from '@nestjs/testing';
+
+import { PrismaService } from '../../src/prisma.service';
+import { KarmaRedemptionService } from '../../src/services/karma-redemption.service';
+
+describe('KarmaRedemptionService', () => {
+  let service: KarmaRedemptionService;
+
+  beforeEach(async () => {
+    const mockPrismaService = {
+      user: { findUnique: jest.fn(), update: jest.fn() },
+      karmaTransaction: {
+        create: jest.fn(),
+        findMany: jest.fn(),
+        findFirst: jest.fn(),
+        update: jest.fn(),
+      },
+      $transaction: jest
+        .fn()
+        .mockImplementation((callback: (prisma: any) => Promise<any>) => {
+          const mockTransaction = {
+            user: { findUnique: jest.fn(), update: jest.fn() },
+            karmaTransaction: { create: jest.fn() },
+          };
+          return Promise.resolve(callback(mockTransaction));
+        }),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        KarmaRedemptionService,
+        {
+          provide: PrismaService,
+          useValue: mockPrismaService,
+        },
+      ],
+    }).compile();
+
+    service = module.get<KarmaRedemptionService>(KarmaRedemptionService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  // Add more tests for redeemReward, getUserRedemptions, updateRedemptionStatus as needed
+});

--- a/server/__tests__/utils/date.util.spec.ts
+++ b/server/__tests__/utils/date.util.spec.ts
@@ -1,0 +1,7 @@
+import { getNow } from '../../src/utils/date.util';
+
+describe('getNow', () => {
+  it('should return a Date object', () => {
+    expect(getNow()).toBeInstanceOf(Date);
+  });
+});

--- a/server/__tests__/utils/feedback.util.spec.ts
+++ b/server/__tests__/utils/feedback.util.spec.ts
@@ -1,0 +1,28 @@
+import {
+  calculateEmojiBreakdown,
+  createEmptyEmojiBreakdown,
+  createDefaultAverageScoreResult,
+} from '../../src/utils/feedback.util';
+
+describe('feedback.util', () => {
+  it('should create empty emoji breakdown', () => {
+    const breakdown = createEmptyEmojiBreakdown();
+    expect(breakdown).toEqual({ 0: 0, 1: 0, 2: 0 });
+  });
+  it('should create default average score result', () => {
+    const result = createDefaultAverageScoreResult();
+    expect(result.averageScore).toBeNull();
+    expect(result.totalFeedback).toBe(0);
+    expect(result.emojiBreakdown).toEqual({ 0: 0, 1: 0, 2: 0 });
+  });
+  it('should calculate emoji breakdown correctly', () => {
+    const feedbackList = [
+      { emoji: 0 },
+      { emoji: 1 },
+      { emoji: 0 },
+      { emoji: 2 },
+    ];
+    const breakdown = calculateEmojiBreakdown(feedbackList);
+    expect(breakdown).toEqual({ 0: 2, 1: 1, 2: 1 });
+  });
+});

--- a/server/__tests__/utils/rideStats.util.spec.ts
+++ b/server/__tests__/utils/rideStats.util.spec.ts
@@ -1,0 +1,14 @@
+import {
+  EARTH_RADIUS_KM,
+  haversineDistance,
+} from '../../src/utils/rideStats.util';
+
+describe('rideStats.util', () => {
+  it('should calculate haversine distance correctly', () => {
+    const d = haversineDistance(0, 0, 0, 1);
+    expect(d).toBeGreaterThan(0);
+  });
+  it('should use correct earth radius', () => {
+    expect(EARTH_RADIUS_KM).toBe(6371);
+  });
+});

--- a/server/__tests__/utils/timeWindow.util.spec.ts
+++ b/server/__tests__/utils/timeWindow.util.spec.ts
@@ -1,0 +1,10 @@
+import { getTimeWindow } from '../../src/utils/timeWindow.util';
+
+describe('getTimeWindow', () => {
+  it('should return correct min and max window', () => {
+    const center = new Date('2025-10-11T12:00:00Z');
+    const { min, max } = getTimeWindow(center, 10);
+    expect(min.getTime()).toBe(center.getTime() - 10 * 60000);
+    expect(max.getTime()).toBe(center.getTime() + 10 * 60000);
+  });
+});

--- a/server/__tests__/utils/voucher.utils.spec.ts
+++ b/server/__tests__/utils/voucher.utils.spec.ts
@@ -1,0 +1,20 @@
+import {
+  addMonthsToDate,
+  generateVoucherId,
+  generateRewardAbbreviation,
+} from '../../src/utils/voucher.utils';
+
+describe('voucher.utils', () => {
+  it('should add months to date', () => {
+    const date = new Date('2025-01-01');
+    const result = addMonthsToDate(date, 2);
+    expect(result.getMonth()).toBe(2); // March (0-based)
+  });
+  it('should generate voucher id', () => {
+    const id = generateVoucherId('Coffee Coupon', 123);
+    expect(id).toMatch(/KARMA-\d{4}-U123-cc/);
+  });
+  it('should generate reward abbreviation', () => {
+    expect(generateRewardAbbreviation('Coffee Shop Coupon')).toBe('CSC');
+  });
+});


### PR DESCRIPTION
## chore: implement unit testing on the server

This pull request introduces a comprehensive unit testing strategy and setup for the backend (NestJS) of the Commuto project. It adds a detailed documentation file outlining best practices and conventions, and migrates/creates a suite of backend unit tests, organizing them into a dedicated `__tests__` directory for improved maintainability and clarity. The backend tests cover controllers, services, and utility functions, with proper mocking of dependencies and adherence to deterministic testing principles.

## Related Issue Ticket:
- #61 

## Summary

- Refactored all backend (NestJS) unit tests into a dedicated `server/__tests__` directory.
- Removed all misplaced `.spec.ts` files from `server/src/` to keep the codebase clean.
- Updated Jest configuration to only run tests from `__tests__`.
- Improved type safety and mocks in all test files.
- Added/updated tests for controllers, services, configs, modules, and utils.
- Updated `UNIT_TESTING.md` documentation to reflect new structure and best practices.

## Why

- To ensure full, professional unit test coverage for the backend.
- To maintain a clean and maintainable codebase.
- To enforce best practices and make future testing easier.

## How to Test

- Run `pnpm test` in the `server/` directory. All tests should pass.
- Review the new `server/__tests__` structure and updated documentation.

## Checklist

- [x] All tests pass
- [x] Documentation updated