### PR TITLE
fix: data not being fetched on first load

### DIFF
--- a/app/src/components/ui/PeopleImpactedWithScore.tsx
+++ b/app/src/components/ui/PeopleImpactedWithScore.tsx
@@ -37,6 +37,10 @@ const PeopleImpactedWithScore = ({ userId }: PeopleAvatarGridProps) => {
 
   // Fetch average score and people impacted data on component mount
   useEffect(() => {
+    if (!userId) {
+      return;
+    }
+
     const fetchData = async () => {
       try {
         const [scoreData, peopleData] = await Promise.all([


### PR DESCRIPTION
This pull request introduces a small but important improvement to the `PeopleImpactedWithScore` component. The change ensures that the data fetching logic is only executed when a valid `userId` is provided, preventing unnecessary API calls and potential errors.

- Added a guard clause in the `useEffect` hook to return early if `userId` is not defined, improving component robustness and efficiency.

## Closes issue #106 