### PR TITLE
feat: implement route guards for guest and protected access

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -26,6 +26,9 @@ import RoleBasedPage from './pages/RoleBasedPage';
 import LogsDashboard from './pages/LogsDashboard';
 import SelfReflection from './pages/SelfReflection';
 
+import { GuestRoute } from './guards/GuestRoute';
+import { ProtectedRoute } from './guards/ProtectedRoute';
+
 import { SocketManager } from './components/SocketManager';
 
 import {
@@ -60,21 +63,82 @@ const App: React.FC = () => {
               <RouterToTop />
               <Navbar />
               <Routes>
+                {/* Public Routes */}
                 <Route path={ROUTE_HOME} element={<Home />} />
                 <Route path={ROUTE_HELP} element={<FAQPage />} />
                 <Route path={ROUTE_ABOUT} element={<AboutPage />} />
-                <Route path={ROUTE_LOGIN} element={<Login />} />
-                <Route path={ROUTE_PROFILE} element={<SelfReflection />} />
-                <Route path={ROUTE_RIDE_DETAILS} element={<RideDetails />} />
-                <Route path={ROUTE_ROLE} element={<RoleBasedPage />} />
                 <Route path={ROUTE_BRAND} element={<Brand />} />
                 <Route path={ROUTE_LEGAL} element={<LegalPage />} />
-                <Route path={ROUTE_LOGS_DASHBOARD} element={<LogsDashboard />} />
-                <Route path={ROUTE_REDEEM} element={<RedeemPage />} />
-                <Route path={ROUTE_VIEW_SCORE} element={<ViewScore />} />
-                <Route path={ROUTE_EARN_KARMA} element={<ViewKarma />} />
                 <Route path={ROUTE_LEADERBOARD} element={<Leaderboard />} />
                 <Route path={ROUTE_404} element={<Error404 />} />
+
+                {/* Guest Routes - Only for unauthenticated users */}
+                <Route
+                  path={ROUTE_LOGIN}
+                  element={
+                    <GuestRoute>
+                      <Login />
+                    </GuestRoute>
+                  }
+                />
+
+                {/* Protected Routes - Require authentication */}
+                <Route
+                  path={ROUTE_PROFILE}
+                  element={
+                    <ProtectedRoute>
+                      <SelfReflection />
+                    </ProtectedRoute>
+                  }
+                />
+                <Route
+                  path={ROUTE_RIDE_DETAILS}
+                  element={
+                    <ProtectedRoute>
+                      <RideDetails />
+                    </ProtectedRoute>
+                  }
+                />
+                <Route
+                  path={ROUTE_ROLE}
+                  element={
+                    <ProtectedRoute>
+                      <RoleBasedPage />
+                    </ProtectedRoute>
+                  }
+                />
+                <Route
+                  path={ROUTE_LOGS_DASHBOARD}
+                  element={
+                    <ProtectedRoute>
+                      <LogsDashboard />
+                    </ProtectedRoute>
+                  }
+                />
+                <Route
+                  path={ROUTE_REDEEM}
+                  element={
+                    <ProtectedRoute>
+                      <RedeemPage />
+                    </ProtectedRoute>
+                  }
+                />
+                <Route
+                  path={ROUTE_VIEW_SCORE}
+                  element={
+                    <ProtectedRoute>
+                      <ViewScore />
+                    </ProtectedRoute>
+                  }
+                />
+                <Route
+                  path={ROUTE_EARN_KARMA}
+                  element={
+                    <ProtectedRoute>
+                      <ViewKarma />
+                    </ProtectedRoute>
+                  }
+                />
               </Routes>
               <Footer />
             </SocketManager>

--- a/app/src/guards/GuestRoute.tsx
+++ b/app/src/guards/GuestRoute.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import { Navigate, useLocation } from 'react-router-dom';
+
+import { useAuth } from '../hooks/useAuth';
+
+import { ROUTE_HOME } from '../constants/routes';
+
+interface GuestRouteProps {
+  children: React.ReactNode;
+}
+
+interface LocationState {
+  from?: {
+    pathname: string;
+  };
+}
+
+/**
+ * GuestRoute - Guards routes that should only be accessible to unauthenticated users
+ * Examples: Login, Register, Forgot Password pages
+ * Redirects authenticated users to their intended destination or home
+ */
+export const GuestRoute: React.FC<GuestRouteProps> = ({ children }) => {
+  const { isAuthenticated } = useAuth();
+  const location = useLocation();
+  const state = location.state as LocationState;
+
+  if (isAuthenticated) {
+    const from = state?.from?.pathname || ROUTE_HOME;
+
+    return <Navigate to={from} replace />;
+  }
+
+  return <>{children}</>;
+};

--- a/app/src/guards/ProtectedRoute.tsx
+++ b/app/src/guards/ProtectedRoute.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { Navigate, useLocation } from 'react-router-dom';
+
+import { useAuth } from '../hooks/useAuth';
+
+import { ROUTE_LOGIN } from '../constants/routes';
+
+interface ProtectedRouteProps {
+  children: React.ReactNode;
+}
+
+/**
+ * ProtectedRoute - Guards routes that require authentication
+ * Redirects unauthenticated users to login, preserving their intended destination
+ */
+export const ProtectedRoute: React.FC<ProtectedRouteProps> = ({ children }) => {
+  const { isAuthenticated } = useAuth();
+  const location = useLocation();
+
+  if (!isAuthenticated) {
+    return <Navigate to={ROUTE_LOGIN} state={{ from: location }} replace />;
+  }
+
+  return <>{children}</>;
+};


### PR DESCRIPTION
## feat: implement route guards for guest and protected access

This pull request introduces route guards to the React application, improving security and user experience by restricting access to certain pages based on authentication status. Two new components, `GuestRoute` and `ProtectedRoute`, have been added and integrated into the routing logic in `App.tsx`. Public, guest-only, and protected routes are now clearly separated and enforced.

### Related issue
- #109 

### What’s Changed

- Introduced `ProtectedRoute` and `GuestRoute` components in a new `guards` folder.
- Updated `App.tsx` to use these guards for authenticated-only and guest-only routes.
- Removed old route guard files and avoided index.ts for consistency.

### Before

- All routes were accessible without authentication checks.
- No clear separation between public, protected, and guest-only routes.

### After

- Authenticated-only pages are now protected (`ProtectedRoute`).
- Login page is only accessible to unauthenticated users (`GuestRoute`).
- Public pages remain open to all.
- Folder structure and imports are consistent with the rest of the codebase.